### PR TITLE
Fix #4: Export applicationGetUseQuartsAccelerators from GUI.Application

### DIFF
--- a/Graphics/UI/Gtk/OSX/Application.chs
+++ b/Graphics/UI/Gtk/OSX/Application.chs
@@ -34,6 +34,7 @@ module Graphics.UI.Gtk.OSX.Application (
   applicationNew,
   applicationReady,
   applicationSetUseQuartsAccelerators,
+  applicationGetUseQuartsAccelerators,
   applicationSetMenuBar,
   applicationSyncMenuBar,
   applicationInsertAppMenuItem,


### PR DESCRIPTION
Adds `applicationGetUseQuartsAccelerators` to list of exported functions.

Note: This does not correct the spelling of the function name. This is covered by #3.
