### PR TITLE
Use gtk2hs-buildtools the library instead of the executables

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -2,11 +2,7 @@
 -- all Gtk2Hs-specific boilerplate is kept in
 -- gtk2hs-buildtools:Gtk2HsSetup
 --
-import Gtk2HsSetup ( gtk2hsUserHooks, checkGtk2hsBuildtools,
-                     typeGenProgram, signalGenProgram, c2hsLocal)
+import Gtk2HsSetup ( gtk2hsUserHooks )
 import Distribution.Simple ( defaultMainWithHooks )
 
-main = do
-  checkGtk2hsBuildtools [typeGenProgram, signalGenProgram, c2hsLocal]
-  defaultMainWithHooks gtk2hsUserHooks
-
+main = defaultMainWithHooks gtk2hsUserHooks

--- a/gtk-mac-integration.cabal-renamed
+++ b/gtk-mac-integration.cabal-renamed
@@ -46,9 +46,6 @@ Library
                         glib  >=0.13.0.0 && <0.14,
                         gtk   >=0.13.0.0 && <0.15
 
-        build-tools:    gtk2hsC2hs >= 0.13.11,
-                        gtk2hsHookGenerator, gtk2hsTypeGen
-
         exposed-modules:
           Graphics.UI.Gtk.OSX
           Graphics.UI.Gtk.OSX.Application

--- a/gtk3-mac-integration.cabal
+++ b/gtk3-mac-integration.cabal
@@ -46,9 +46,6 @@ Library
                         glib  >=0.13.0.0 && <0.14,
                         gtk3  >=0.13.0.0 && <0.15
 
-        build-tools:    gtk2hsC2hs >= 0.13.11,
-                        gtk2hsHookGenerator, gtk2hsTypeGen
-
         exposed-modules:
           Graphics.UI.Gtk.OSX
           Graphics.UI.Gtk.OSX.Application


### PR DESCRIPTION
I'm having trouble with building this library using `cabal new-build` due to this error:

```
Cannot find gtk2hsTypeGen
Please install `gtk2hs-buildtools` first and check that the install directory is in your PATH (e.g. HOME/.cabal/bin).
cabal: Failed to build gtk-mac-integration-0.3.3.1. See the build log above for details.
```

This MR fixes the issue by using the library version of `gtk2hs-buildtools`.