### PR TITLE
Relax upper version bounds for Cabal and gtk/gtk3

### DIFF
--- a/gtk-mac-integration.cabal-renamed
+++ b/gtk-mac-integration.cabal-renamed
@@ -38,13 +38,13 @@ Source-Repository head
 
 custom-setup
   setup-depends: base >= 4.6,
-                 Cabal >= 1.24 && < 1.25,
+                 Cabal >= 1.24 && < 2.5,
                  gtk2hs-buildtools >= 0.13.1.0 && < 0.14
 
 Library
         build-depends:  base >= 4 && < 5, array -any, containers -any, mtl -any,
                         glib  >=0.13.0.0 && <0.14,
-                        gtk   >=0.13.0.0 && <0.15
+                        gtk   >=0.13.0.0 && <0.16
 
         exposed-modules:
           Graphics.UI.Gtk.OSX

--- a/gtk3-mac-integration.cabal
+++ b/gtk3-mac-integration.cabal
@@ -38,13 +38,13 @@ Source-Repository head
 
 custom-setup
   setup-depends: base >= 4.6,
-                 Cabal >= 1.24 && < 1.25,
+                 Cabal >= 1.24 && < 2.5,
                  gtk2hs-buildtools >= 0.13.1.0 && < 0.14
 
 Library
         build-depends:  base >= 4 && < 5, array -any, containers -any, mtl -any,
                         glib  >=0.13.0.0 && <0.14,
-                        gtk3  >=0.13.0.0 && <0.15
+                        gtk3  >=0.13.0.0 && <0.16
 
         exposed-modules:
           Graphics.UI.Gtk.OSX


### PR DESCRIPTION
This PR updates dependencies to make the library buildable with GHC 8.6.4.